### PR TITLE
Correct dependency for react native slider

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@
 import React from 'react';
 
 import {
-	PickerIOS,
 	Platform,
 } from 'react-native';
+import {PickerIOS} from '@react-native-community/picker';
 
 import WheelCurvedPicker from './WheelCurvedPicker'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wheel-picker",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React native cross platform picker.",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "keywords": [
     "react-native",
     "picker",
-	"wheel"
+    "wheel"
   ],
   "author": "Yu Zheng",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/lesliesam/react-native-wheel-picker#readme",
   "dependencies": {
-    "@react-native-community/react-native-picker": "1.4.0"
+    "@react-native-community/picker": "1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/lesliesam/react-native-wheel-picker#readme",
   "dependencies": {
-    "@react-native-community/datetimepicker": "1.4.0"
+    "@react-native-community/react-native-picker": "1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/lesliesam/react-native-wheel-picker/issues"
   },
   "homepage": "https://github.com/lesliesam/react-native-wheel-picker#readme",
-  "dependencies": {
+  "peerDependencies": {
     "@react-native-community/picker": "1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,7 @@
     "url": "https://github.com/lesliesam/react-native-wheel-picker/issues"
   },
   "homepage": "https://github.com/lesliesam/react-native-wheel-picker#readme",
-  "dependencies": {}
+  "dependencies": {
+    "@react-native-community/datetimepicker": "1.4.0"
+  }
 }


### PR DESCRIPTION
Correct the warning about iospicker removal from react native main package.
It is now replaced by an independent package.